### PR TITLE
Fix depthai ver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 akari-client[depthai]
 akari-proto
+depthai==2.15.0


### PR DESCRIPTION
手をかなり近づけると落ちるバグがありました。100%下記エラーで落ちます。

> [194430107181F31200] [1.7] [18.930] [system] [critical] Fatal error. Please report to developers. Log: 'ResourceLocker' '358'

ストリーミングの画面サイズを超えるくらい近づけないと発生しないので今まで気付きませんでした。
デバッグしたところ、下記の”cam_out"のframeのget()に失敗して落ちていました。それ以上の原因はよくわかりません。
https://github.com/geaxgx/depthai_hand_tracker/blob/97731232fffd467e8de2c3a34ab8382962bb385e/HandTrackerEdge.py#L462

https://github.com/luxonis/depthai/issues/874
上記のissueを見たところdepthaiのバージョンが2.15であれば落ちないとのことでした。
試したところ落ちなくなったので、このアプリのvenvではdepthaiのバージョンを2.15.0に固定します。