### PR TITLE
Fix depthai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 akari-client[depthai]
 akari-proto
-depthai==2.15.0
+depthai


### PR DESCRIPTION
以前depthaiのバージョンが最新だと起動できなかったので2.15.0に固定した(はず)ですが、現在の最新2.24.0だと起動できるのでバージョン指定を削除
むしろ2.15.0はRaspberry pi OS bookwormだとビルドができずインストールに失敗します。